### PR TITLE
fix `ignore` option, support `bare` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = function(file, passedOptions) {
     if (!options.coverageVar && options.instrumentor === 'istanbul') {
         options.coverageVar = ISTANBUL_COVERAGE_VAR;
     }
+    if (typeof options.bare === 'undefined') options.bare = true;
     ignore = defaultIgnore.concat(options.ignore || []);
     options.ignore = null;
     instrumentor = new CoverageInstrumentor(options);
@@ -57,6 +58,7 @@ module.exports = function(file, passedOptions) {
                 sourceMap: true,
                 generatedFile: file,
                 inline: true,
+                bare: options.bare,
                 literate: false
             });
             transformed = new Buffer(data.js);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var through = require('through2');
 var coffee = require('coffee-script');
 var coffeeCoverage = require('coffee-coverage');
 var minimatch = require('minimatch');
+var assign = require('object-assign');
 
 var CoverageInstrumentor = coffeeCoverage.CoverageInstrumentor;
 // Just use the default Istanbul coverage variable.
@@ -25,9 +26,10 @@ var defaultIgnore = [
  * `options.noInit` {Boolean} - default to `false`. Use this if you do not want the initialization (which adds the file
  * being transformed to the global coverage object). There may be cases where you'd want to control this.
  */
-module.exports = function(file, options) {
-    var ignore, instrumentor;
-    if (!options) options = {};
+module.exports = function(file, passedOptions) {
+    var ignore, instrumentor,
+    options = {};
+    if (passedOptions) assign(options, passedOptions);
     if (!options.coverageVar && options.instrumentor === 'istanbul') {
         options.coverageVar = ISTANBUL_COVERAGE_VAR;
     }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "coffee-script": "^1.9.2",
     "istanbul": "^0.3.13",
     "minimatch": "^2.0.7",
+    "object-assign": "^2.0.0",
     "through2": "^0.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- `options` argument was being mutated, and `options.ignore` overwritten (set to `null`) every time the function is invoked, and, therefore, only the first file has been tested for proper ignore patterns, the rest have been tested only for default ones.
- `options.bare` is now supported and gets passed to coffee-coverage instrumenter or coffee compiler (when file is ignored); defaults to `true` to match `coffeeify` behavior (and because it makes sense -- the code is put into a closure by the `browserify` anyway).
