### PR TITLE
Enable Literate CoffeeScript mode for ".litcoffee" files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # browserify-coffee-coverage
 
-A browserify transform to take `.coffee` files and compile them into `.js` with coverage instrumentation using
-[coffee-coverage](https://github.com/benbria/coffee-coverage). `coffee-coverage` supports
+A browserify transform to take `.coffee` and `.litcoffee` files and compile them into `.js` with coverage
+instrumentation using [coffee-coverage](https://github.com/benbria/coffee-coverage). `coffee-coverage` supports
 [istanbul](https://github.com/gotwarlost/istanbul) and [jscoverage](http://siliconforks.com/jscoverage/)
 
 # Usage

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(file, passedOptions) {
                 generatedFile: file,
                 inline: true,
                 bare: options.bare,
-                literate: false
+                literate: path.extname(file) === '.litcoffee'
             });
             transformed = new Buffer(data.js);
         }


### PR DESCRIPTION
This PR enables `literate` in CoffeeScript compiler options for `.litcoffee` files.

_Edit_: documented it in `README.md`.

Adding an option for this seems unneeded: I can't imagine a case where overriding this would be useful.

I couldn't run the tests on my Windows system, so can't add a test for this feature. Our options here are:
- Rewrite the test scripts to be cross-platform.
- Leave this PR without a test (somebody will probably need to write it separately).

This closes #2.
